### PR TITLE
feat: support inline colors

### DIFF
--- a/application.go
+++ b/application.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
@@ -116,9 +117,15 @@ func NewApplication(name, title, version string, opts ...ApplicationOptionFunc) 
 		SilenceErrors:      true,
 		SilenceUsage:       true,
 		DisableSuggestions: true,
+		PersistentPreRun: func(*cobra.Command, []string) {
+			if flags.NoColors {
+				pterm.DisableStyling()
+			}
+		},
 	}
 	app.rootCommand.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveNoFileComp)
 	app.rootCommand.SetOut(app.output.writer)
+	pterm.SetDefaultOutput(app.output.writer)
 
 	if err := setupFlags(app.rootCommand, nil, app.flags, app.rootCommand.PersistentFlags()); err != nil {
 		return nil, nil, fmt.Errorf("failed to setup application flags: %w", err)

--- a/examples/pretty_output/main.go
+++ b/examples/pretty_output/main.go
@@ -29,6 +29,13 @@ func main() {
 			out.Warnln("A warning message.")
 			out.Errorln("An error message.")
 
+			// Messages with inline colors
+
+			out.Println("An <info>informational</info> message.")
+			out.Println("A <warn>warning</warn> message.")
+			out.Println("An <error>error</error> message.")
+			out.Println("Some <info>info</info>, a <warn>warning</warn> and an <error>error</error>.")
+
 			// Output based on verbosity levels
 
 			out.Verboseln("A verbose message, only shown when the application is run with -v or more.")

--- a/flag.go
+++ b/flag.go
@@ -23,6 +23,9 @@ const (
 type GlobalFlags struct {
 	// VerboseLevel indicates the verbosity level of the application.
 	VerboseLevel Count `name:"verbose" short:"v" usage:"Set verbosity level. Use -v for verbose, -vv for debug, -vvv for trace."`
+
+	// NoColors can be used to disable colored output.
+	NoColors bool `name:"no-colors" usage:"Disable colors in the output."`
 }
 
 // IsVerbose checks if the application is running in verbose mode (-v).


### PR DESCRIPTION
This adds support for inline colors using a set of predefined "levels":

- info
- warn
- error

For instance:

```go
out.Println("An <info>informational</info> message.")
out.Println("A <warn>warning</warn> message.")
out.Println("An <error>error</error> message.")
```

When used, these will be styled with the same color as when using the respective methods in the OutputWriter (Info, Warn and Error). Multiple tags can be used in a single string.