### PR TITLE
feat: support inline colors in table

### DIFF
--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,0 +1,61 @@
+package color
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/pterm/pterm"
+)
+
+// coloredText is a regular expression that matches custom tags for info, warn, and error formatting inline in a string.
+var coloredText = regexp.MustCompile(`<(info|warn|error)>(.*?)</(info|warn|error)>`)
+
+// Colorize applies colorization to a string based on custom tags.
+func Colorize(s string) string {
+	return coloredText.ReplaceAllStringFunc(s, func(s string) string {
+		m := coloredText.FindStringSubmatch(s)
+		openTag, content, closeTag := m[1], m[2], m[3]
+
+		if openTag != closeTag {
+			return s
+		}
+
+		var printer func(...any) string
+		switch openTag {
+		case "info":
+			printer = pterm.FgLightCyan.Sprint
+		case "warn":
+			printer = pterm.FgYellow.Sprint
+		case "error":
+			printer = pterm.FgLightRed.Sprint
+		default:
+			return s
+		}
+
+		return printer(content)
+	})
+}
+
+// ColorizeAny applies colorization to a slice of values. Each value will be converted to a string.
+func ColorizeAny(s []any) []any {
+	ret := make([]any, len(s))
+	for i, str := range s {
+		ret[i] = Colorize(fmt.Sprint(str))
+	}
+	return ret
+}
+
+// ColorizeStrings applies colorization to a slice of strings.
+func ColorizeStrings(s []string) []string {
+	as := make([]any, len(s))
+	for i, v := range s {
+		as[i] = v
+	}
+
+	coloredAny := ColorizeAny(as)
+	for i, v := range coloredAny {
+		s[i] = v.(string)
+	}
+
+	return s
+}

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -1,0 +1,45 @@
+package color
+
+import "testing"
+
+func TestColorize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{
+			name: "no tags",
+			in:   "This is a test string.",
+			out:  "This is a test string.",
+		},
+		{
+			name: "info tag",
+			in:   "This is an <info>informational</info> message.",
+			out:  "This is an \x1b[96minformational\x1b[0m message.",
+		},
+		{
+			name: "warn tag",
+			in:   "This is a <warn>warning</warn> message.",
+			out:  "This is a \x1b[33mwarning\x1b[0m message.",
+		},
+		{
+			name: "error tag",
+			in:   "This is an <error>error</error> message.",
+			out:  "This is an \x1b[91merror\x1b[0m message.",
+		},
+		{
+			name: "mixed tags",
+			in:   "<info>Info</info>, <warn>Warn</warn>, and <error>Error</error> messages.",
+			out:  "\x1b[96mInfo\x1b[0m, \x1b[33mWarn\x1b[0m, and \x1b[91mError\x1b[0m messages.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Colorize(tt.in); got != tt.out {
+				t.Errorf("Colorize() = %v, want %v", got, tt.out)
+			}
+		})
+	}
+}

--- a/output/table.go
+++ b/output/table.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/nais/naistrix/internal/color"
 	"github.com/pterm/pterm"
 )
 
@@ -86,7 +87,12 @@ func (t *Table) convert(v any) (pterm.TableData, error) {
 
 	if elem := vt.Elem(); elem.Kind() == reflect.Slice && elem.Elem().Kind() == reflect.String {
 		if d, ok := v.([][]string); ok {
-			return d, nil
+			ret := make(pterm.TableData, len(d))
+			ret[0] = d[0]
+			for i := 1; i < len(d); i++ {
+				ret[i] = color.ColorizeStrings(d[i])
+			}
+			return ret, nil
 		}
 
 		return nil, fmt.Errorf("unable to convert data")
@@ -190,5 +196,5 @@ func getStringValue(v reflect.Value) string {
 		return ""
 	}
 
-	return fmt.Sprint(v.Interface())
+	return color.Colorize(fmt.Sprint(v.Interface()))
 }


### PR DESCRIPTION
Extract the colorize functions to an internal package and start using them in the table writer as well.

This should now be possible:

```go
data := [][]string{
	{"Name", "Email", "Age"}, // first row is used as headers
	{"Alice", "<info>alice</info>@example.com", "30"},
	{"Bob", "<info>bob</info>@example.com", "42"},
}
return out.Table().Render(data)
```

It should also work when using structs for the table data.