### PR TITLE
fix: show usage on errors

### DIFF
--- a/application.go
+++ b/application.go
@@ -156,7 +156,6 @@ func NewApplication(name, title, version string, opts ...ApplicationOptionFunc) 
 		Short:              app.title,
 		Version:            app.version,
 		SilenceErrors:      true,
-		SilenceUsage:       true,
 		DisableSuggestions: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := app.initializeConfig(cmd.Flags()); err != nil {


### PR DESCRIPTION
We seem to silence usage text on errors. Can't remember the reasoning behind this, but removing the option to show usage text on errors from now on.