### PR TITLE
feat(input): return ErrNotInteractive instead of blocking without a t…

### DIFF
--- a/input/confirm.go
+++ b/input/confirm.go
@@ -30,6 +30,10 @@ func Confirm(prompt string, opts ...ConfirmOptionFunc) (bool, error) {
 		o(options)
 	}
 
+	if !interactive() {
+		return false, ErrNotInteractive
+	}
+
 	return pterm.DefaultInteractiveConfirm.
 		WithDefaultValue(options.defaultValue).
 		Show(prompt)

--- a/input/export_test.go
+++ b/input/export_test.go
@@ -1,0 +1,9 @@
+package input
+
+// SetInteractive overrides the interactivity detection and returns a function that restores the previous behaviour. It
+// is only available to tests.
+func SetInteractive(f func() bool) (restore func()) {
+	prev := interactive
+	interactive = f
+	return func() { interactive = prev }
+}

--- a/input/input.go
+++ b/input/input.go
@@ -8,5 +8,8 @@ import (
 
 // Input prompts the user for a free-form string value and returns the response.
 func Input(prompt string) (string, error) {
+	if !interactive() {
+		return "", ErrNotInteractive
+	}
 	return pterm.DefaultInteractiveTextInput.Show(prompt)
 }

--- a/input/interactive.go
+++ b/input/interactive.go
@@ -1,0 +1,19 @@
+package input
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// ErrNotInteractive is returned by the prompt functions in this package when there is no interactive terminal available
+// to read input from, for example when running in CI or when standard input or output is piped.
+var ErrNotInteractive = errors.New("no interactive terminal available")
+
+// interactive reports whether prompts can read from an interactive terminal. Both standard input and standard output
+// must be terminals: standard input so a response can be read, and standard output so the user can see the prompt. It is
+// a package variable so tests can override the detection.
+var interactive = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd())) // #nosec G115
+}

--- a/input/main_test.go
+++ b/input/main_test.go
@@ -1,0 +1,46 @@
+package input_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/nais/naistrix/input"
+)
+
+// TestMain forces interactivity on for the simulated-keyboard tests in this package, which do not run against a real
+// terminal.
+func TestMain(m *testing.M) {
+	restore := input.SetInteractive(func() bool { return true })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
+
+func TestPrompts_NotInteractive(t *testing.T) {
+	restore := input.SetInteractive(func() bool { return false })
+	defer restore()
+
+	if _, err := input.Input("prompt"); !errors.Is(err, input.ErrNotInteractive) {
+		t.Errorf("Input: expected ErrNotInteractive, got %v", err)
+	}
+	if _, err := input.Confirm("prompt"); !errors.Is(err, input.ErrNotInteractive) {
+		t.Errorf("Confirm: expected ErrNotInteractive, got %v", err)
+	}
+	if _, err := input.Select("prompt", []string{"alpha", "beta"}); !errors.Is(err, input.ErrNotInteractive) {
+		t.Errorf("Select: expected ErrNotInteractive, got %v", err)
+	}
+}
+
+func TestSelect_AutoSelectSingleOptionWithoutTerminal(t *testing.T) {
+	restore := input.SetInteractive(func() bool { return false })
+	defer restore()
+
+	result, err := input.Select("prompt", []string{"only"}, input.SelectWithAutoSelectSingleOption())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "only" {
+		t.Errorf("expected %q, got %q", "only", result)
+	}
+}

--- a/input/select.go
+++ b/input/select.go
@@ -2,8 +2,6 @@ package input
 
 import (
 	"fmt"
-	"maps"
-	"slices"
 
 	"github.com/pterm/pterm"
 )
@@ -44,17 +42,23 @@ func Select[T any](prompt string, selection []T, opts ...SelectOptionFunc) (T, e
 		return selection[0], nil
 	}
 
-	labels := make(map[string]struct{})
+	labels := make([]string, 0, len(selection))
+	seen := make(map[string]struct{}, len(selection))
 	for i, o := range selection {
 		lbl := fmt.Sprint(o)
-		if _, exists := labels[lbl]; exists {
+		if _, exists := seen[lbl]; exists {
 			return empty, fmt.Errorf("duplicate label: %s (index %d)", lbl, i)
 		}
-		labels[lbl] = struct{}{}
+		seen[lbl] = struct{}{}
+		labels = append(labels, lbl)
+	}
+
+	if !interactive() {
+		return empty, ErrNotInteractive
 	}
 
 	chosen, err := pterm.DefaultInteractiveSelect.
-		WithOptions(slices.Collect(maps.Keys(labels))).
+		WithOptions(labels).
 		WithFilterInputPlaceholder("[type to filter]").
 		Show(prompt)
 	if err != nil {


### PR DESCRIPTION
…erminal

Prompt helpers (Input, Confirm, Select) now detect a non-interactive stdin/stdout and return ErrNotInteractive so callers don't each reimplement a terminal guard. Select also preserves caller option order instead of randomizing it via map iteration.